### PR TITLE
wonolog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,8 @@ npm-debug.log
 .build
 
 # Logs
-log
+log/*
+!log/.gitkeep
 *.log
 
 # Sensitive files

--- a/composer.json
+++ b/composer.json
@@ -86,6 +86,7 @@
     "wpackagist-plugin/popups": "~1.8",
     "generoi/popups-extended": "^1.0.0-alpha",
 
+    "inpsyde/wonolog": "^1.0",
     "mcguffin/acf-quick-edit-fields": "^2.4",
     "wpackagist-plugin/duplicate-post": "^3.2",
     "wpackagist-plugin/debug-bar": "^1.0",

--- a/config/application.php
+++ b/config/application.php
@@ -136,6 +136,10 @@ Config::define('WPMS_SMTP_AUTH', env('WPMS_SMTP_AUTH') ?: false);
  */
 Config::define('WP_DEBUG_DISPLAY', false);
 Config::define('SCRIPT_DEBUG', false);
+Config::define('WONOLOG_ENABLED', true);
+Config::define('WONOLOG_LOG_DIR', $root_dir . '/log');
+Config::define('WONOLOG_LOG_LEVEL', 'NOTICE');
+Config::define('WONOLOG_MAX_FILES', 30);
 ini_set('display_errors', 0);
 
 /**

--- a/deploy.php
+++ b/deploy.php
@@ -21,8 +21,9 @@ set('branch', 'master');
 set('default_stage', 'production');
 set('ssh_multiplexing', true);
 
+set('cache_dir', 'web/app/cache');
 set('shared_files', ['.env']);
-set('shared_dirs', ['web/app/uploads', '{{cache_dir}}']);
+set('shared_dirs', ['web/app/uploads', 'log', '{{cache_dir}}']);
 set('writable_dirs', get('shared_dirs'));
 
 set('bin/robo', './vendor/bin/robo');

--- a/web/app/mu-plugins/wonolog.php
+++ b/web/app/mu-plugins/wonolog.php
@@ -1,0 +1,40 @@
+<?php
+/*
+Plugin Name:  Wonolog
+Plugin URI:   https://genero.fi
+Description:  Enable Wonolog
+Version:      1.0.0
+Author:       Genero
+Author URI:   https://genero.fi/
+License:      MIT License
+*/
+
+namespace Genero\Site;
+
+use Inpsyde\Wonolog;
+use Monolog\Handler;
+use Monolog\Logger;
+
+if (!is_blog_installed()) {
+    return;
+}
+
+if (defined('WONOLOG_LOG_DIR') && defined('WONOLOG_ENABLED') && WONOLOG_ENABLED) {
+    if (!is_dir(WONOLOG_LOG_DIR) || !is_writable(WONOLOG_LOG_DIR)) {
+        return;
+    }
+
+    $max_files = defined('WONOLOG_MAX_FILES') ? WONOLOG_MAX_FILES : 30;
+    $log_level = defined('WONOLOG_LOG_LEVEL') ? WONOLOG_LOG_LEVEL : Logger::NOTICE;
+    $handler = new Handler\RotatingFileHandler(WONOLOG_LOG_DIR . '/{date}.log', $max_files, $log_level);
+    $handler->setFilenameFormat('{date}', 'Y-m-d');
+
+    Wonolog\bootstrap($handler, Wonolog\USE_DEFAULT_PROCESSOR)
+        ->use_hook_listener(new Wonolog\HookListener\DbErrorListener())
+        ->use_hook_listener(new Wonolog\HookListener\FailedLoginListener())
+        ->use_hook_listener(new Wonolog\HookListener\HttpApiListener())
+        ->use_hook_listener(new Wonolog\HookListener\MailerListener())
+        ->use_hook_listener(new Wonolog\HookListener\QueryErrorsListener())
+        ->use_hook_listener(new Wonolog\HookListener\CronDebugListener())
+        ->use_hook_listener(new Wonolog\HookListener\WpDieHandlerListener());
+}


### PR DESCRIPTION
This adds [Wonolog](https://inpsyde.github.io/Wonolog/), the WordPress wrapper for [Monolog](https://github.com/Seldaek/monolog). There's quite a lot of docs so we shouldn't expect developers to actually read through this and make changes... Monolog is used in pretty much every PHP platform except for WP :)

It can be configured to send emails, slack notifications or pretty much anything on different log levels. This setup adds rotating daily logs in `log/` folder outside of webroot. This has already been quite useful in helping to show more details errors (eg. from curl).

Example entry:

> [2019-06-06 15:09:50] HTTP.ERROR: WP HTTP API Error: cURL error 28: Resolving timed out after 5525 milliseconds - Response code: . {"transport":"Requests","context":"response","query_args":{"method":"GET","timeout":5,"redirection":5,"httpversion":"1.0","user-agent":"WordPress/5.2.1; http://sage.test","reject_unsafe_urls":false,"blocking":true,"headers":[],"cookies":[],"body":null,"compress":false,"decompress":true,"sslverify":true,"sslcertificates":"/var/www/wordpress/web/wp/wp-includes/certificates/ca-bundle.crt","stream":false,"filename":null,"limit_response_size":null,"_redirection":5},"url":"https://jetpack.com/is-idc-allowed/"} {"wp":{"doing_cron":false,"doing_ajax":true,"is_admin":true}}

To [add a debug statement manually](https://inpsyde.github.io/Wonolog/docs/02-basic-wonolog-concepts.html):

```
do_action('wonolog.log', [
    'message' => 'Something happened.',
    'channel' => 'DEBUG',
    'level'   => 100,
    'context' => [],
]);
```

What do you guys think? Do we want something like this? Tracking down WP errors in the JNT error logs can be quite difficult with PHP-FPM.