### PR TITLE
add show-environment-in-admin-bar

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,6 +88,7 @@
 
     "mcguffin/acf-quick-edit-fields": "^2.4",
     "wpackagist-plugin/duplicate-post": "^3.2",
+    "wpackagist-plugin/show-environment-in-admin-bar": "^1.1",
     "wpackagist-plugin/debug-bar": "^1.0",
     "wpackagist-plugin/kint-debugger": "~1.0",
     "wpackagist-plugin/regenerate-thumbnails": "~3.0",
@@ -126,7 +127,7 @@
       "post-merge": "composer install:development"
     },
     "installer-paths": {
-      "web/app/mu-plugins/{$name}/": ["type:wordpress-muplugin"],
+      "web/app/mu-plugins/{$name}/": ["type:wordpress-muplugin", "wpackagist-plugin/show-environment-in-admin-bar"],
       "web/app/plugins/{$name}/": ["type:wordpress-plugin"],
       "web/app/themes/{$name}/": ["type:wordpress-theme"]
     },

--- a/config/environments/development.php
+++ b/config/environments/development.php
@@ -13,6 +13,7 @@ Config::define('WPML_DEBUG_INSTALLER', true);
 Config::define('WP_DEBUG_LOG', true);
 Config::define('WP_CACHE', false);
 Config::define('WP_DISABLE_FATAL_ERROR_HANDLER', true);
+Config::define('SHC_SHOW_ENV_DEV', 'dev');
 
 /** Access /wp/wp-admin/maint/repair.php **/
 Config::define('WP_ALLOW_REPAIR', true);

--- a/config/environments/staging.php
+++ b/config/environments/staging.php
@@ -13,3 +13,5 @@ use Roots\WPConfig\Config;
  * Example: `Config::define('WP_DEBUG', true);`
  * Example: `Config::define('DISALLOW_FILE_MODS', false);`
  */
+
+Config::define('SHC_SHOW_ENV_STAGING', 'staging');


### PR DESCRIPTION
Adds a notice in the top corner of the admin bar about which environment you're on. This will work out of the box without configuration.

<img width="200" alt="Screen Shot 2019-06-10 at 19 12 41" src="https://user-images.githubusercontent.com/302736/59230442-dde9ba80-8bb3-11e9-9bed-3bb0442a8892.png">
<img width="200" alt="Screen Shot 2019-06-10 at 19 16 34" src="https://user-images.githubusercontent.com/302736/59230619-68cab500-8bb4-11e9-8f89-39ae0d6df1f8.png">
