### PR TITLE
add jetpack with predefined modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,14 +80,10 @@
     "wpackagist-plugin/wp-performance-pack": "~2.0",
     "wpackagist-plugin/ewww-image-optimizer": "~4.0",
 
-    "wpackagist-plugin/widget-options": "~3.3",
-    "generoi/widget-options-extended": "~2.1.0-alpha",
-
     "wpackagist-plugin/popups": "~1.8",
     "generoi/popups-extended": "^1.0.0-alpha",
 
     "mcguffin/acf-quick-edit-fields": "^2.4",
-    "wpackagist-plugin/duplicate-post": "^3.2",
     "wpackagist-plugin/show-environment-in-admin-bar": "^1.1",
     "wpackagist-plugin/debug-bar": "^1.0",
     "wpackagist-plugin/kint-debugger": "~1.0",
@@ -100,7 +96,8 @@
     "generoi/genero-conf": "~1.1",
     "generoi/genero-status": "*",
     "consolidation/robo": "^1.3",
-    "generoi/robo-genero": "^0.2.2"
+    "generoi/robo-genero": "^0.2.2",
+    "wpackagist-plugin/jetpack": "^7.3"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.0.2",

--- a/config/application.php
+++ b/config/application.php
@@ -121,6 +121,8 @@ Config::define('WPCACHEHOME', Config::get('WP_CONTENT_DIR') . '/plugins/wp-super
 Config::define('WP_HIDE_DONATION_BUTTONS', true);
 Config::define('EWWW_IMAGE_OPTIMIZER_SKIP_BUNDLE', true);
 Config::define('WP_DEFAULT_THEME', '<example-project>/resources');
+// Do not connect Jetpack to a WP account.
+Config::define('JETPACK_DEV_DEBUG', true);
 
 /** WP Mail SMTP hardcoded configuration */
 Config::define('WPMS_ON', true);

--- a/web/app/mu-plugins/jetpack.php
+++ b/web/app/mu-plugins/jetpack.php
@@ -1,0 +1,34 @@
+<?php
+/*
+Plugin Name:  Jetpack Configurations
+Plugin URI:   https://genero.fi
+Description:  Jetpack Configurations
+Version:      1.0.0
+Author:       Genero
+Author URI:   https://genero.fi/
+License:      MIT License
+*/
+
+namespace Genero\Site;
+
+// This filter does not get called correctly in the theme.
+add_filter('jetpack_active_modules', function ($modules) {
+    $modules = array_merge($modules, [
+        // https://jetpack.com/support/carousel/
+        // 'carousel',
+        // https://jetpack.com/support/copy-post-2/
+        'copy-post',
+        // https://jetpack.com/support/contact-form/
+        'contact-form',
+        // https://jetpack.com/support/infinite-scroll/
+        // 'infinite-scroll',
+        // https://jetpack.com/support/lazy-images/
+        // 'lazy-images',
+        // https://jetpack.com/support/markdown/
+        'markdown',
+        // https://jetpack.com/support/widget-visibility/
+        'widget-visibility',
+    ]);
+
+    return array_values($modules);
+});


### PR DESCRIPTION
Jetpacks adds functionality that replaces a few of our other default plugins and as it's maintained by Automattic and used on wordpress.com it gets a lot of good features.

One questionable addition here is keeping the activated modules in code but by default there's a ton of modules we do not want. Might be better to have developers manage this plugin through code rather than UI. What do you guys think?

The [contact form module](https://jetpack.com/support/contact-form/) can replace Gravityforms with a Gutenberg form builder on simple forms.

If you need more widget options such as custom classes etc `widget-options` is still a good plugin but for 90% of the websites we build we just need to limit widgets per page.