### PR TITLE
disable acf admin ui in production

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -119,6 +119,8 @@ Config::define('WP_CACHE', true);
 Config::define('WPCACHEHOME', Config::get('WP_CONTENT_DIR') . '/plugins/wp-super-cache/');
 Config::define('WP_HIDE_DONATION_BUTTONS', true);
 Config::define('EWWW_IMAGE_OPTIMIZER_SKIP_BUNDLE', true);
+// Disable ACF Admin UI when in production
+Config::define('ACF_LITE', true);
 // Do not connect Jetpack to a WP account.
 Config::define('JETPACK_DEV_DEBUG', true);
 

--- a/config/environments/development.php
+++ b/config/environments/development.php
@@ -15,6 +15,7 @@ Config::define('WP_DEBUG_LOG', true);
 Config::define('WP_CACHE', false);
 Config::define('WP_DISABLE_FATAL_ERROR_HANDLER', true);
 Config::define('SHC_SHOW_ENV_DEV', 'dev');
+Config::define('ACF_LITE', false);
 
 /** Access /wp/wp-admin/maint/repair.php **/
 Config::define('WP_ALLOW_REPAIR', true);


### PR DESCRIPTION
What do you think? If someone ever edits the fields on production the changes will be lost with next deploy anyways. Better not to hide it entirely or keep it there so people can still check the fields on production? As we have docker working it's less of a hassle to spin up a local instance.