### PR TITLE
vscode will exclude .build dir

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "files.exclude": {
+    "**/.build": true
+  },
+  "files.watcherExclude": {
+    "**/.build": true,
+  }
+}


### PR DESCRIPTION
There is really no reason VS code will need to watch this directory