### PR TITLE
add mu-plugin to prevent user enumeration using wp pretty urls

### DIFF
--- a/web/app/mu-plugins/stop-user-enumeration.php
+++ b/web/app/mu-plugins/stop-user-enumeration.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+Plugin Name:  Stop User Enumeration
+Plugin URI:   https://genero.fi
+Description:  Do not allow user enumeration using WP pretty URLs.
+Version:      1.0.0
+Author:       Genero
+Author URI:   https://genero.fi/
+License:      MIT License
+*/
+
+namespace Genero\Site;
+
+if (!is_blog_installed()) {
+    return;
+}
+
+add_action('init', function () {
+    if (is_admin()) {
+        return;
+    }
+
+    if (!preg_match('/author=([0-9]*)/i', $_SERVER['QUERY_STRING'] ?? '')) {
+        return;
+    }
+
+    add_filter('query_vars', function (array $query_vars) {
+        foreach (['author', 'author_name'] as $var) {
+            $key = array_search($var, $query_vars);
+            if ($key !== false) {
+                unset($query_vars[$key]);
+            }
+        }
+        return $query_vars;
+    });
+});


### PR DESCRIPTION
eg ?author=1 -> /authors/admin
see https://wordpress.stackexchange.com/a/255680/196163

In addition you can also get a list of users in  /wp-json/wp/v2/users but it only shows users who has written posts so it's "considered fine".