### PR TITLE
feat: make production images available on local machine for ngnix setup

### DIFF
--- a/.ddev/nginx/uploads-redirect.conf
+++ b/.ddev/nginx/uploads-redirect.conf
@@ -1,0 +1,4 @@
+# Live uploads available on local machine
+if (!-e $request_filename) {
+  rewrite ^/app/uploads/(.*)$ https://<example-project>.kinsta.cloud/app/uploads/$1 last;
+}


### PR DESCRIPTION
while setting up the project <example-project> will be replaced with the sitename, Usually we are using same name on Kinsta account so this should work on all projects.

this ddev snippet will proxy production images on local machine.