### PR TITLE
Add to cart behaviour

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,6 @@
     "stoutlogic/acf-builder": "^1.12",
     "spatie/laravel-google-fonts": "^1.2",
     "generoi/sage-woocommerce": "^1.1",
-    "generoi/sage-cachetags": "^1.1",
     "wpackagist-plugin/safe-svg": "^2.1",
     "wpackagist-plugin/limit-login-attempts-reloaded": "^2.6.1",
     "wpackagist-plugin/wp-sanitize-file-name-plus": "^1.0",
@@ -80,7 +79,8 @@
     "generoi/genero-cmp": "^2.0",
     "generoi/wp-image-resizer": "^1.0",
     "spatie/laravel-csp": "^2.10",
-    "10up/wpcli-vulnerability-scanner": "^1.2"
+    "10up/wpcli-vulnerability-scanner": "^1.2",
+    "wpackagist-plugin/woo-ajax-add-to-cart": "^2.4"
   },
   "require-dev": {
     "brainmaestro/composer-git-hooks": "^3.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d8f9d8863914c1406f5db0fa0f436ce4",
+    "content-hash": "3f4807593b80fc1d23c4659bbe68c251",
     "packages": [
         {
             "name": "10up/wpcli-vulnerability-scanner",
@@ -2011,57 +2011,6 @@
                 "source": "https://github.com/generoi/robo-genero/tree/v0.4.7"
             },
             "time": "2024-05-24T13:40:47+00:00"
-        },
-        {
-            "name": "generoi/sage-cachetags",
-            "version": "v1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/generoi/sage-cachetags.git",
-                "reference": "076027388c14b4c93b4414d8154af3eb88bcfad8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/generoi/sage-cachetags/zipball/076027388c14b4c93b4414d8154af3eb88bcfad8",
-                "reference": "076027388c14b4c93b4414d8154af3eb88bcfad8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.4",
-                "roots/acorn": "*"
-            },
-            "require-dev": {
-                "squizlabs/php_codesniffer": "~3.0"
-            },
-            "type": "library",
-            "extra": {
-                "acorn": {
-                    "providers": [
-                        "Genero\\Sage\\CacheTags\\CacheTagsServiceProvider"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Genero\\Sage\\CacheTags\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Oskar Schöldström",
-                    "email": "public@oxy.fi"
-                }
-            ],
-            "homepage": "https://github.com/generoi/sage-cachetags",
-            "support": {
-                "issues": "https://github.com/generoi/sage-cachetags/issues",
-                "source": "https://github.com/generoi/sage-cachetags/tree/v1.2.0"
-            },
-            "time": "2024-07-19T14:21:57+00:00"
         },
         {
             "name": "generoi/sage-woocommerce",
@@ -11952,6 +11901,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/user-switching/"
+        },
+        {
+            "name": "wpackagist-plugin/woo-ajax-add-to-cart",
+            "version": "2.4.1",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/woo-ajax-add-to-cart/",
+                "reference": "tags/2.4.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/woo-ajax-add-to-cart.2.4.1.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/woo-ajax-add-to-cart/"
         },
         {
             "name": "wpackagist-plugin/woocommerce",

--- a/web/app/themes/gds/resources/views/partials/header.blade.php
+++ b/web/app/themes/gds/resources/views/partials/header.blade.php
@@ -82,8 +82,10 @@
 
     @if ($is_webshop)
       <div class="header__actions">
-        @block('woocommerce/mini-cart')
-        @block('woocommerce/customer-account', ['displayStyle' => 'icon_only'])
+        @blocks
+          <!-- wp:woocommerce/mini-cart {"addToCartBehaviour":"open_drawer"} /-->
+          <!-- wp:woocommerce/customer-account {"displayStyle":"icon_only"} /-->
+        @endblocks
       </div>
     @endif
 


### PR DESCRIPTION
I don't necessarily need to merge this, just making a PR so that you can see and comment.
The woo-ajax-add-to-cart worked and made single page start working with add to cart behaviour open_drawer

Will still also change the woocommerce service provider into a plugin as we discussed