### PR TITLE
Add npm min-release-age=7d cooldown to .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+# Wait 7 days after a package version is published before allowing install.
+# Defense against rapid-publish supply-chain attacks (typosquats, compromised
+# maintainer credentials, malicious post-install scripts). Requires npm >=11.10;
+# silently ignored by older npm, so safe to commit.
+min-release-age=7d


### PR DESCRIPTION
## Summary

Adds `min-release-age=7d` to `.npmrc` — npm refuses to install package versions younger than 7 days.

## Why

Defense against rapid-publish supply-chain attacks:
- Typosquatted package names
- Versions published from compromised maintainer accounts
- Malicious post-install scripts pushed under a legitimate maintainer account

By the time a malicious package has been live for a week, it has typically been flagged and yanked. This shifts the install-time risk window from "minutes after publish" to "after a week of public scrutiny."

## How it works

- Requires **npm >= 11.10** ([released Feb 2026](https://socket.dev/blog/npm-introduces-minimumreleaseage-and-bulk-oidc-configuration)). Older npm silently ignores the key, so committing this is safe regardless of which Node/npm any single dev/CI is on — progressive enhancement.
- Applies to `npm install`, lockfile updates, and CI installs alike.
- Does **not** affect already-installed packages — only blocks new installs of fresh versions.

## Test plan

- [ ] `npm install` runs normally with no behavior change for established packages.
- [ ] If an urgent pin is needed for a brand-new release, temporarily comment out the line; npm has no per-package exclusion mechanism yet.
