### PR TITLE
fix: remove orphaned taxonomy template extending deleted category view

### DIFF
--- a/web/app/themes/gds/resources/views/taxonomy.blade.php
+++ b/web/app/themes/gds/resources/views/taxonomy.blade.php
@@ -1,1 +1,0 @@
-@extends('category')


### PR DESCRIPTION
## Problem

`taxonomy.blade.php` contains only `@extends('category')`, but `category.blade.php` no longer exists in this theme — it was removed when category/tag/taxonomy archives were consolidated into `archive.blade.php` (and its `Archive` view composer). Any custom-taxonomy archive request renders `taxonomy.blade.php`, Blade fails to resolve the missing `category` view, and it throws `InvalidArgumentException: View [category] not found` — an uncaught exception that produces an error page.

This is the same bug fixed in medihealth (generoi/medihealth#42), found by sweeping GDS-theme repos for the same signature.

## Fix

Delete `taxonomy.blade.php`. Taxonomy requests then fall through the Sage template hierarchy to `archive.blade.php`, whose `Archive` composer (`app/View/Composers/Archive.php`) already handles `is_tax() || is_category() || is_tag()` and supplies the required `$content`/`query` data.

Note: repointing to `@extends('archive')` is not used because the `Archive` composer binds to the `archive`/`home` view names; letting the request resolve to the `archive` view directly ensures the composer runs.

## Verification

- Confirmed `category.blade.php` is absent and `archive.blade.php` + the `Archive` composer (handling `is_tax/is_category/is_tag`) are present in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
