### PR TITLE
Fix .npmrc min-release-age: value is days, not seconds

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,4 +2,4 @@
 # Defense against rapid-publish supply-chain attacks (typosquats, compromised
 # maintainer credentials, malicious post-install scripts). Requires npm >=11.10;
 # silently ignored by older npm, so safe to commit.
-min-release-age=604800
+min-release-age=7


### PR DESCRIPTION
`min-release-age` is interpreted by npm as a number of **days**, not seconds.

npm's own config flattener (`@npmcli/config`) computes the cutoff as:

```js
flatOptions.before = new Date(Date.now() - (86400000 * obj['min-release-age']))
```

`86400000` ms = one day, so the value is multiplied by *days*.

- `604800` → 604800 days (~1656 years) → cutoff lands in year **370 AD** → npm rejects
  **every** package version (`ENOVERSIONS`/`ETARGET`), breaking all installs.
- `7d` → invalid (config type is `Number`, not a string) → parsed as `null` → the
  cooldown is silently **disabled** (no protection at all).
- `7` → 7 days → correct.

This restores the intended 7-day supply-chain quarantine. Verified against npm
11.14.1: `7` blocks releases <7 days old and allows older ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
