### PR TITLE
Read deploy host from robo.yml instead of shelling out to robo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,15 @@ jobs:
         run: composer test --no-interaction
 
       - name: Add remote public keys to known hosts
-        run: ssh-keyscan -p $(./vendor/bin/robo config env.@${{ inputs.environment }}.port || echo 22) $(./vendor/bin/robo config env.@${{ inputs.environment }}.host) >> ~/.ssh/known_hosts
+        env:
+          DEPLOY_ENV: ${{ inputs.environment }}
+        # Read robo.yml directly rather than shelling out to `robo`, which
+        # prints PHP deprecation notices on stdout that command substitution
+        # would feed to ssh-keyscan as hostnames. Matches generoi/github-actions.
+        run: |
+          ssh-keyscan \
+            -p $(yq ".env[\"@${DEPLOY_ENV}\"].port // 22" robo.yml) \
+            $(yq ".env[\"@${DEPLOY_ENV}\"].host" robo.yml) >> ~/.ssh/known_hosts
 
       - name: Deploy
         run: ./vendor/bin/dep deploy ${{ inputs.environment }} ${{ inputs.log_level }}


### PR DESCRIPTION
Part of an org-wide sweep. Same fix as generoi/seafront#12 and generoi/github-actions#46.

## Problem

```bash
ssh-keyscan -p $(./vendor/bin/robo config env.@<env>.port || echo 22) \
               $(./vendor/bin/robo config env.@<env>.host)
```

`symfony/console` 7.4 deprecates `Application::add()`, which `consolidation/robo` still calls. PHP prints that notice on **stdout**, so command substitution captures it and splits it into arguments — every word arrives at `ssh-keyscan` as a hostname:

```
getaddrinfo Since: Temporary failure in name resolution
getaddrinfo removed: Temporary failure in name resolution
getaddrinfo "Symfony\Component\Console\Application::addCommand()": Name or service not known
```

This took down the seafront production deploy ([run](https://github.com/generoi/seafront/actions/runs/30529417361)). The vulnerability-remediation updates are rolling `symfony/console` forward across the estate, so every repo on the old form is on borrowed time.

## Fix

Read `robo.yml` with `yq`, keeping PHP out of the substitution entirely — matching the shared `generoi/github-actions` deploy workflow.

## Verification

- The rewritten workflow parses as YAML, and no `robo config env.` reference remains.
- The `yq` expressions were checked against this repo's own `robo.yml`: the environment keys resolve, and `// 22` covers environments with no explicit `port`.
- Behaviour was reproduced with a stub `robo` emitting the real notice: the old form handed `ssh-keyscan` **51 arguments**, the new form hands it **3** (`-p <port> <host>`).

Note `2>/dev/null` does not help here (the notice is on stdout), and neither does `head -n1` — PHP emits a blank line first, so it returns an empty string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
