### PR TITLE
fix(ci): strip both agent env vars so pint emits checkstyle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -196,7 +196,7 @@
     ],
     "ci": [
       "@composer validate --no-check-all",
-      "pint --format=checkstyle | vendor/bin/cs2pr",
+      "env -u AI_AGENT -u CLAUDECODE pint --format=checkstyle | vendor/bin/cs2pr",
       "npm run ci:scripts --silent | while read xml; do echo $xml | ./vendor/bin/cs2pr; done",
       "npm run ci:styles --silent | while read xml; do echo $xml | ./vendor/bin/cs2pr; done"
     ],


### PR DESCRIPTION
`composer ci` fails on clean code whenever it runs from a coding-agent session.

Pint 1.30 detects an agent environment and emits JSON regardless of `--format=checkstyle`, so the `| vendor/bin/cs2pr` pipe gets `{"tool":"pint","result":"passed"}` and dies with `Start tag expected, '<' not found`, exiting 2.

Both `CLAUDECODE` and `AI_AGENT` trigger it, and **stripping only one is not enough**. The `env -u CLAUDECODE -u CLAUDE_CODE` form previously committed across several repos does not work — `CLAUDE_CODE` is not a real variable (the real ones are `CLAUDECODE`, `AI_AGENT`, and `CLAUDE_CODE_*`), so `AI_AGENT` survives and still forces JSON. Verified against a repo carrying that fix: `composer ci` still exits 2.

**This is a no-op in CI.** Neither variable is set there, and `env -u FOO cmd` with `FOO` unset is exactly `cmd` — verified. Only local agent-driven runs change behaviour. All existing flags and path arguments are preserved verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)