### PR TITLE
security: update WordPress core to 7.0.3

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -7219,7 +7219,7 @@
         },
         {
             "name": "roots/wordpress",
-            "version": "7.0",
+            "version": "7.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/roots/wordpress.git",
@@ -7250,7 +7250,7 @@
             ],
             "support": {
                 "issues": "https://github.com/roots/wordpress/issues",
-                "source": "https://github.com/roots/wordpress/tree/7.0"
+                "source": "https://github.com/roots/wordpress/tree/7.0.3"
             },
             "funding": [
                 {
@@ -7329,23 +7329,23 @@
         },
         {
             "name": "roots/wordpress-no-content",
-            "version": "7.0",
+            "version": "7.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress.git",
-                "reference": "7.0"
+                "reference": "7.0.3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.w.org/release/wordpress-7.0-no-content.zip",
-                "reference": "7.0",
-                "shasum": "2ffdd31a747f68e3e5633064993997a7ce881975"
+                "url": "https://downloads.w.org/release/wordpress-7.0.3-no-content.zip",
+                "reference": "7.0.3",
+                "shasum": "01b2b8fb953b747de9ac8176b6d05aae1cc410b6"
             },
             "require": {
                 "php": ">= 7.4"
             },
             "provide": {
-                "wordpress/core-implementation": "7.0"
+                "wordpress/core-implementation": "7.0.3"
             },
             "suggest": {
                 "ext-curl": "Performs remote request operations.",
@@ -7396,7 +7396,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-05-20T18:34:28+00:00"
+            "time": "2026-08-06T21:41:49+00:00"
         },
         {
             "name": "roots/wp-config",


### PR DESCRIPTION
Bumps `roots/wordpress` / `roots/wordpress-no-content` **7.0 → 7.0.3**.

[WordPress 7.0.3](https://wordpress.org/news/2026/08/wordpress-7-0-3-release/) (released 2026-08-06) is a security release fixing **12 vulnerabilities**; the fixes were backported to every supported branch, and `7.0.3` is the patched release for this site's branch. The headline issue:

- **Pre-auth reflected XSS on the login screen**, with potential to lead to PHP code execution — [CVE-2026-64638 / GHSA-52p2-r8wf-jcrf](https://github.com/WordPress/wordpress-develop/security/advisories/GHSA-52p2-r8wf-jcrf), **CVSS 8.9 (High)**, `CVSS:4.0/AV:N/AC:H/AT:N/PR:N/UI:A/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H`. Affects all WordPress 4.7.0–7.0.2.

The remaining issues (4× Contributor+ stored XSS, multisite privilege escalation, SSRF in URL validation, Author+ CSS injection, two info-disclosure issues, post slug enumeration, email confirmation bypass) all require at least a contributor account or are lower impact.

**Why this is a manual PR:** the nightly vulnerability scan will not catch this yet — no advisory for WordPress core has been published to the Packagist / wpsecadv databases that `composer audit` reads, so the scan currently reports clean.

Stays within this repo's existing `composer.json` constraint — lock-only change, no minor/major jump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)