### PR TITLE
fix(csp): correct the header name and make the policy survivable

### DIFF
--- a/web/app/themes/gds/app/Csp/BasicWithoutNonce.php
+++ b/web/app/themes/gds/app/Csp/BasicWithoutNonce.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Csp;
+
+use Spatie\Csp\Directive;
+use Spatie\Csp\Keyword;
+use Spatie\Csp\Policy;
+use Spatie\Csp\Presets\Basic;
+
+// Spatie's Basic preset calls addNonce(STYLE), which makes CSP3 browsers
+// ignore 'unsafe-inline' for style-src — blocking every WordPress core /
+// plugin inline <style> tag (none of them carry a nonce). We can't add
+// nonces to WP's inline styles globally, so drop the style nonce and let
+// 'unsafe-inline' (added in WordPress.php) cover them.
+//
+// The script nonce is dropped here too and added by WordPress.php instead,
+// which is where 'strict-dynamic' lives — that keyword authorises scripts by
+// nonce alone, so the two belong together.
+class BasicWithoutNonce extends Basic
+{
+    public function configure(Policy $policy): void
+    {
+        $policy
+            ->add(Directive::BASE, Keyword::SELF)
+            ->add(Directive::CONNECT, Keyword::SELF)
+            ->add(Directive::DEFAULT, Keyword::SELF)
+            ->add(Directive::FONT, Keyword::SELF)
+            ->add(Directive::FORM_ACTION, Keyword::SELF)
+            ->add(Directive::FRAME, Keyword::SELF)
+            ->add(Directive::IMG, Keyword::SELF)
+            ->add(Directive::MEDIA, Keyword::SELF)
+            ->add(Directive::OBJECT, Keyword::NONE)
+            ->add(Directive::SCRIPT, Keyword::SELF)
+            ->add(Directive::STYLE, Keyword::SELF);
+    }
+}

--- a/web/app/themes/gds/app/Providers/ContentSecurityPolicyServiceProvider.php
+++ b/web/app/themes/gds/app/Providers/ContentSecurityPolicyServiceProvider.php
@@ -20,6 +20,21 @@ class ContentSecurityPolicyServiceProvider extends ServiceProvider
         if (! config('csp.enabled')) {
             return;
         }
+
+        // wp-admin cannot work under a nonce. Core prints inline scripts that
+        // never pass through `wp_inline_script_attributes` — `ajaxurl` in
+        // admin-header.php among them — so they can never carry one, and a
+        // nonce anywhere in script-src makes the browser ignore
+        // 'unsafe-inline'. The result is `ajaxurl is not defined`.
+        //
+        // Spatie's Basic, GoogleAnalytics and GoogleTagManager presets add a
+        // nonce unconditionally, so omitting it in App\Csp\WordPress is not
+        // enough on its own. Turning the generator off covers every preset at
+        // once, and admin keeps a real policy ('self' plus 'unsafe-inline').
+        if (is_admin()) {
+            config(['csp.nonce_enabled' => false]);
+        }
+
         $policy = Policy::create(
             presets: config('csp.presets'),
             directives: config('csp.directives'),
@@ -39,7 +54,11 @@ class ContentSecurityPolicyServiceProvider extends ServiceProvider
         header('Referrer-Policy: strict-origin-when-cross-origin');
 
         // Add Content-Security-Policy
-        header(sprintf('Content-Security-Policys: %s', $policy->getContents()), true);
+        $header = config('csp.report_only')
+            ? 'Content-Security-Policy-Report-Only'
+            : 'Content-Security-Policy';
+
+        header(sprintf('%s: %s', $header, $policy->getContents()), true);
     }
 
     public function addScriptNonce(array $attributes): array

--- a/web/app/themes/gds/config/csp.php
+++ b/web/app/themes/gds/config/csp.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Csp\BasicWithoutNonce;
 use App\Csp\GoogleAds;
 use App\Csp\GoogleTagManagerPreview;
 use App\Csp\SampleContent;
@@ -8,7 +9,6 @@ use App\Csp\WordPress;
 use App\Csp\YouTube;
 use Spatie\Csp\Nonce\RandomString;
 use Spatie\Csp\Presets\AdobeFonts;
-use Spatie\Csp\Presets\Basic;
 use Spatie\Csp\Presets\GoogleAnalytics;
 use Spatie\Csp\Presets\GoogleFonts;
 use Spatie\Csp\Presets\GoogleTagManager;
@@ -22,7 +22,7 @@ return [
      * any class that extends `Spatie\Csp\Preset`
      */
     'presets' => [
-        Basic::class,
+        BasicWithoutNonce::class,
         GoogleFonts::class,
         AdobeFonts::class,
         GoogleAnalytics::class,
@@ -65,6 +65,14 @@ return [
      * A great service you could use for this is https://report-uri.com/
      */
     'report_uri' => env('CSP_REPORT_URI', ''),
+
+    /*
+     * Send the policy as Content-Security-Policy-Report-Only, which reports
+     * violations without blocking anything. Deploy any policy change this way
+     * first and check the console before enforcing — an enforcing policy that
+     * has never run is untested by definition.
+     */
+    'report_only' => env('CSP_REPORT_ONLY', false),
 
     /*
      * Headers will only be added if this setting is set to true.


### PR DESCRIPTION
The template emits the header as `Content-Security-Policys`, so **no site scaffolded from bedrock has ever had a CSP applied**. Every site that inherited it carries the same dormant bug: `feelia`, `kaskipuu`, `lofs`, `maptilat`, `seafront` (each already has its own draft PR for this).

Fixing the spelling on its own is the dangerous part — it enforces, for the first time, a policy nobody has tested. When steripolarnew corrected it today, `steripolar.dk` immediately lost Cookiebot, the consent banner and all 18 webfonts. So the changes that make it survivable ship together:

- **`BasicWithoutNonce`** replaces Spatie's `Basic`. `Basic` calls `addNonce(STYLE)`, and a nonce makes browsers ignore `unsafe-inline` — which is exactly what `WordPress.php` adds, because WordPress emits inline styles that can never carry a nonce. Matches beamex, holmasto, solving and steripolarnew.
- **Nonce generator off in wp-admin.** Presets add a script nonce unconditionally; core prints inline scripts that can never carry one (`ajaxurl` among them), so admin dies with `ajaxurl is not defined`. Disabling the generator for admin requests covers every preset at once, and admin keeps a real policy.
- **`CSP_REPORT_ONLY`** switches the header to `Content-Security-Policy-Report-Only`, so a policy can be validated against real traffic before it can block anything.

## Rollout

Draft deliberately. For any site adopting this: set `CSP_REPORT_ONLY=true`, deploy, check the console on a few frontend pages and one admin screen, fix what reports, then remove the flag.

Known offenders found while doing exactly this on live sites today:

- **Cookiebot** prints its scripts from raw PHP templates — needs the "Support CSP" patch (already used on btbtransformers, hakonen, kaskipuu, niva, talliosake)
- **limit-login-attempts-reloaded** prints a raw script tag after a failed login — absent on the first page view, which makes it easy to miss
- **Self-hosted webfonts** can bake an absolute origin into `@font-face`; clearing the cache regenerates them per origin
- **Theme templates** printing raw script tags instead of using `wp_get_inline_script_tag()`

Not verified in a browser — this is the template, so verification happens per site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
